### PR TITLE
Update Hydrogen-blog.gemspec

### DIFF
--- a/Hydrogen-blog.gemspec
+++ b/Hydrogen-blog.gemspec
@@ -1,12 +1,12 @@
 # encoding: utf-8
 
 Gem::Specification.new do |s|
-  s.name          = "Material Theme For Jekyll"
+  s.name          = "Material_Theme_For_Jekyll"
   s.version       = "1.0"
   s.license       = "CC0-1.0"
   s.authors       = ["Link"]
   s.email         = ["lk@atlinker.cn"]
-  s.homepage      = "hydrogen.atlinker.cn"
+  s.homepage      = "https://hydrogen.atlinker.cn"
   s.summary       = "Hydrogen,clean and quick response Theme For Jekyll, with your Customizable comment system "
 
   s.files         = `git ls-files -z`.split("\x0").select do |f|


### PR DESCRIPTION
根据实际编译情况，其中name项不能有空格，且uri需要有http:// 才能通过编译