### PR TITLE
Remove Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,6 @@ paginate_path: "page:num"
 background: https://api.dujin.org/bing/1920.php
 theme_color: 546E7A
 
-google_analytics:
 # hydrogen-blog date format
 # refer to http://shopify.github.io/liquid/filters/date/ if you want to customize this
 hydrogen-blog:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -130,18 +130,6 @@
       </footer>
     </section>
 
-    {% comment %}{% if site.google_analytics %}
-      <script type="text/javascript">
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        ga('create', '{{ site.google_analytics }}', 'auto');
-        ga('send', 'pageview');
-      </script>
-    {% endif %}{% endcomment %}
-
     {% if site.MathJax %}
     <script type="text/x-mathjax-config">
   MathJax.Hub.Config({


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/